### PR TITLE
Appset name service

### DIFF
--- a/charts/applicationset/Chart.yaml
+++ b/charts/applicationset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-applicationsets-services
 description: A HELM Chart for ArgoCD ApplicationSets for Kubernetes
 type: application
-version: &version "0.8.25"
+version: &version "0.9.1"
 appVersion: *version
 kubeVersion: ">= 1.23"
 home: https://github.com/saidsef/argocd-applicationsets-services
@@ -23,7 +23,9 @@ annotations:
   artifacthub.io/license: "Apache-2.0"
   artifacthub.io/changes: |
     - kind: changed
-      description: Updated GitLab repoURL to also include GitLan API override
+      description: Updated to add AppSet name as suffix to GitHub and GitLab App names
+    - kind: changed
+      description: Renamed GitLab file from pr to mr as suffix
   artifacthub.io/links: |
     - name: README
       url: https://raw.githubusercontent.com/saidsef/argocd-applicationsets-services/main/README.md

--- a/charts/applicationset/templates/github-pr.yml
+++ b/charts/applicationset/templates/github-pr.yml
@@ -19,7 +19,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: '{{ required "A valid repo name is required" $repo.name }}-github'
+  name: '{{ required "A valid repo name is required" $repo.name }}-github-{{ $name }}'
   namespace: {{ required "A valied namespace is required" $namespace | replace "." "-" }}
   labels:
     app.kubernetes.io/name: {{ $repo.name }}

--- a/charts/applicationset/templates/gitlab-mr.yml
+++ b/charts/applicationset/templates/gitlab-mr.yml
@@ -18,7 +18,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: '{{ required "A valid repo name is required" $repo.name }}-gitlab'
+  name: '{{ required "A valid repo name is required" $repo.name }}-gitlab-{{ $name }}'
   namespace: {{ required "A valied namespace is required" $namespace | replace "." "-" }}
   labels:
     app.kubernetes.io/name: {{ $repo.name }}


### PR DESCRIPTION
- Chart version bump
- Rename GitLab pr to mr, this correctly names the suffix to merge-request
- Add AppSet name as suffix to GitLab app name
- Add AppSet name as suffix to GitHub app name
- Add changelog entries

These changes allow us to deploy multiple applications that will not have name collision.

Closes: #100