### PR TITLE
chore: ping codeql action version

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -78,10 +78,10 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.17
+        uses: github/codeql-action/init@60168efe1c415ce0f5521ea06d5c2062adbeed1b #v3.28.17
         continue-on-error: true
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.17
+        uses: github/codeql-action/analyze@60168efe1c415ce0f5521ea06d5c2062adbeed1b #v3.28.17
         continue-on-error: true
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -92,7 +92,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3.28.17
+        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b #v3.28.17
         with:
           sarif_file: 'trivy-results.sarif'
 


### PR DESCRIPTION
## What?
Updated CodeQL action references in GitHub workflows to use commit hash instead of version tag.

## Why?
This change improves security by pinning the CodeQL actions to specific commit hashes rather than version tags, which prevents potential supply chain attacks. Using commit hashes ensures the exact version of the action is used consistently.

## How?
Modified `.github/workflows/charts.yml` to reference CodeQL actions with commit hash `60168efe1c415ce0f5521ea06d5c2062adbeed1b` while maintaining the version comment `#v3.28.17` for reference. The following actions were updated:
- github/codeql-action/init
- github/codeql-action/analyze
- github/codeql-action/upload-sarif

This PR closes #210