### PR TITLE
feat(kustomize): add namespace field to GitHub PR and GitLab MR templates

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -117,6 +117,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Run K8s test
         run: |
+          kubectl cluster-info
           kubectl create ns argocd
           kubectl apply --server-side -k https://github.com/argoproj/argo-cd/manifests/crds\?ref\=stable -n argocd
           helm upgrade -i appsets charts/applicationset --namespace argocd --create-namespace

--- a/charts/applicationset/Chart.yaml
+++ b/charts/applicationset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-applicationsets-services
 description: A Helm chart for ArgoCD ApplicationSets, a declarative, GitOps continuous delivery tool for Kubernetes
 type: application
-version: &version "0.17.2"
+version: &version "0.18.0"
 appVersion: *version
 kubeVersion: ">= 1.31"
 home: https://github.com/saidsef/argocd-applicationsets-services
@@ -24,7 +24,7 @@ annotations:
   artifacthub.io/license: "Apache-2.0"
   artifacthub.io/changes: |
     - kind: added
-      description: Add branch_slug to info section in gitlab and github PR templates
+      description: Add kustomize namespace to GitHub PR and GitLab MR templates with coalesce fallback to mr-branch_slug-number
   artifacthub.io/links: |
     - name: README
       url: https://raw.githubusercontent.com/saidsef/argocd-applicationsets-services/main/README.md

--- a/charts/applicationset/templates/github-pr.yml
+++ b/charts/applicationset/templates/github-pr.yml
@@ -87,6 +87,7 @@ spec:
         {{- else }}
         targetRevision: {{ or $repo.targetRevision $branch $headShortSha "HEAD" }}
         kustomize:
+          namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) }}
           commonAnnotations:
             app.kubernetes.io/instance: '{{ $repo.name }}'
             app.kubernetes.io/part-of: {{ coalesce $github.label $globals.label }}

--- a/charts/applicationset/templates/gitlab-mr.yml
+++ b/charts/applicationset/templates/gitlab-mr.yml
@@ -83,6 +83,7 @@ spec:
         {{- else }}
         targetRevision: {{ or $repo.targetRevision $branch $headShortSha "HEAD" }}
         kustomize:
+          namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) }}
           commonAnnotations:
             app.kubernetes.io/instance: '{{ $repo.name }}'
             app.kubernetes.io/part-of: {{ coalesce $gitlab.label $globals.label }}


### PR DESCRIPTION
## What

Adds a `namespace` field to the `kustomize` section in both the GitHub PR and GitLab MR ApplicationSet templates.

## Why

Without an explicit namespace, kustomize deployments inherit whatever namespace is set elsewhere, which can cause resources to land in the wrong place when running multiple preview environments side by side. Setting the namespace per-PR keeps environments isolated.

## How

Uses `coalesce` to resolve the namespace in order of preference:

1. `repo.namespace` - per-repo override in values
2. `globals.deployToNamespace` - global fallback in values
3. `mr-<branch_slug>-<number>` - auto-generated from the PR/MR metadata

## Chart

Updated `artifacthub.io/changes` in `Chart.yaml` to document the addition.