### PR TITLE
fix(templates): quote namespace values in GitHub PR and GitLab MR templates

### DIFF
--- a/charts/applicationset/Chart.yaml
+++ b/charts/applicationset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-applicationsets-services
 description: A Helm chart for ArgoCD ApplicationSets, a declarative, GitOps continuous delivery tool for Kubernetes
 type: application
-version: &version "0.18.0"
+version: &version "0.18.1"
 appVersion: *version
 kubeVersion: ">= 1.31"
 home: https://github.com/saidsef/argocd-applicationsets-services
@@ -23,8 +23,8 @@ sources:
 annotations:
   artifacthub.io/license: "Apache-2.0"
   artifacthub.io/changes: |
-    - kind: added
-      description: Add kustomize namespace to GitHub PR and GitLab MR templates with coalesce fallback to mr-branch_slug-number
+    - kind: fixed
+      description: Quote namespace values in GitHub PR and GitLab MR templates to handle special characters
   artifacthub.io/links: |
     - name: README
       url: https://raw.githubusercontent.com/saidsef/argocd-applicationsets-services/main/README.md

--- a/charts/applicationset/templates/github-pr.yml
+++ b/charts/applicationset/templates/github-pr.yml
@@ -87,7 +87,7 @@ spec:
         {{- else }}
         targetRevision: {{ or $repo.targetRevision $branch $headShortSha "HEAD" }}
         kustomize:
-          namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) }}
+          namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) | quote }}
           commonAnnotations:
             app.kubernetes.io/instance: '{{ $repo.name }}'
             app.kubernetes.io/part-of: {{ coalesce $github.label $globals.label }}
@@ -122,7 +122,7 @@ spec:
         {{- else }}
         server: {{ $server }}
         {{- end }}
-        namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) }}
+        namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) | quote }}
       info:
         - name: author
           value: '{{ $dqf }}author{{ $dqb }}'

--- a/charts/applicationset/templates/gitlab-mr.yml
+++ b/charts/applicationset/templates/gitlab-mr.yml
@@ -83,7 +83,7 @@ spec:
         {{- else }}
         targetRevision: {{ or $repo.targetRevision $branch $headShortSha "HEAD" }}
         kustomize:
-          namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) }}
+          namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) | quote }}
           commonAnnotations:
             app.kubernetes.io/instance: '{{ $repo.name }}'
             app.kubernetes.io/part-of: {{ coalesce $gitlab.label $globals.label }}
@@ -115,7 +115,7 @@ spec:
         {{- else }}
         server: {{ $server }}
         {{- end }}
-        namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) }}
+        namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) | quote }}
       info:
         - name: author
           value: '{{ $dqf }}author{{ $dqb }}'


### PR DESCRIPTION
## What

Pipes the `coalesce` output through `| quote` on both `kustomize.namespace` and `destination.namespace` in the GitHub PR and GitLab MR ApplicationSet templates.

## Why

Without quoting, a namespace value containing spaces or special characters (e.g. from `repo.namespace` or `globals.deployToNamespace`) would produce invalid YAML and cause the ApplicationSet to fail rendering. The `printf` fallback is safe on its own, but the user-supplied inputs are not.

## Where

Four lines touched — two per template:

- `kustomize.namespace` (affects kustomize resource transformation)
- `destination.namespace` (affects ArgoCD sync target)

Both now emit a quoted string, which is valid YAML regardless of the input value.