### PR TITLE
chore(chart): modernise ApplicationSet templates and fix all-cluster deploys

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -120,8 +120,7 @@ jobs:
           kubectl cluster-info
           kubectl create ns argocd
           kubectl apply --server-side -k https://github.com/argoproj/argo-cd/manifests/crds\?ref\=stable -n argocd
-          helm upgrade -i appsets charts/applicationset --namespace argocd --create-namespace
-          helm list -A
+          helm template appsets charts/applicationset --namespace argocd | kubectl apply --server-side --force-conflicts -n argocd -f -
           kubectl get all -A
           kubectl get applications -A -o wide
           kubectl get applicationsets -A -o wide

--- a/charts/applicationset/Chart.yaml
+++ b/charts/applicationset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argocd-applicationsets-services
 description: A Helm chart for ArgoCD ApplicationSets, a declarative, GitOps continuous delivery tool for Kubernetes
 type: application
-version: &version "0.18.1"
+version: &version "0.20.0"
 appVersion: *version
 kubeVersion: ">= 1.31"
 home: https://github.com/saidsef/argocd-applicationsets-services
@@ -23,8 +23,18 @@ sources:
 annotations:
   artifacthub.io/license: "Apache-2.0"
   artifacthub.io/changes: |
+    - kind: changed
+      description: "Migrate ApplicationSet templates to Go Template (goTemplate: true), replacing the deprecating fasttemplate syntax"
+    - kind: changed
+      description: "BREAKING - update template tokens in your repo image tags, values and parameters from {{branch_slug}} to {{ .branch_slug }} (and likewise .number, .head_short_sha etc.)"
+    - kind: added
+      description: Configurable goTemplateOptions and preserveResourcesOnDeletion, GitLab pullRequestState, insecure and caRef, and multi-label PR/MR filtering
     - kind: fixed
-      description: Quote namespace values in GitHub PR and GitLab MR templates to handle special characters
+      description: "server=all now works - render a matrix generator (clusters x pullRequest) so each preview deploys to every registered cluster; previously it emitted an invalid 'server: all' destination"
+    - kind: added
+      description: GitLab MR ApplicationSets now set managedNamespaceMetadata for parity with GitHub
+    - kind: changed
+      description: "Internal - deduplicate the GitHub and GitLab generators into shared named templates and remove unused chart helpers"
   artifacthub.io/links: |
     - name: README
       url: https://raw.githubusercontent.com/saidsef/argocd-applicationsets-services/main/README.md

--- a/charts/applicationset/templates/_helpers.tpl
+++ b/charts/applicationset/templates/_helpers.tpl
@@ -115,7 +115,10 @@ Expected dict keys:
 {{- $retryBackoffDuration := .retryBackoffDuration }}
   template:
     metadata:
-      name: {{ .nameFormat }}
+      {{- /* server=all fans out over a clusters x pullRequest matrix; without the
+             cluster name the Application name collides across clusters and only one
+             is created. nameNormalized is the RFC-1123 safe cluster name. */}}
+      name: {{ .nameFormat }}{{ if eq $server "all" }}-{{ $dqf }} .nameNormalized {{ $dqb }}{{ end }}
       labels:
         app.kubernetes.io/name: {{ $repo.name }}
         app.kubernetes.io/branch: {{ trunc 63 $branchSlug | trimSuffix "-" }}

--- a/charts/applicationset/templates/_helpers.tpl
+++ b/charts/applicationset/templates/_helpers.tpl
@@ -1,21 +1,13 @@
 {{/*
 Copyright (c) 2018 Said Sef
-Expand the name of the chart.
 */}}
-{{- define "chart.name" -}}
-{{- default .Values.name .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
 
 {{- define "chart.namespace" -}}
 {{- default .Values.namespace | replace "." "-" }}
 {{- end }}
 
-{{- define "chart.notificationChannel" -}}
-{{- coalesce .Values.notificationChannel .Values.globals.notificationChannel }}
-{{- end }}
-
 {{- define "chart.server" -}}
-{{- coalesce .Values.server .Values.globals.server | squote }}
+{{- coalesce .Values.server .Values.globals.server }}
 {{- end }}
 
 {{- define "chart.refresh" -}}
@@ -27,50 +19,183 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+GitHub pull request generator body (emitted from column 0; the caller places it
+with `- {{ include ... | nindent N | trim }}` so it reads standalone or nested
+inside a matrix generator). Expected dict keys: github, globals, repo, refresh.
 */}}
-{{- define "chart.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{- define "chart.githubGenerator" -}}
+{{- $github := .github -}}
+{{- $globals := .globals -}}
+{{- $repo := .repo -}}
+{{- $refresh := .refresh -}}
+pullRequest:
+  github:
+    api: {{ $github.api }}
+    owner: {{ required "A valid repo organization / owner is required" $github.owner }}
+    repo: {{ required "A valid repo name is required" $repo.name }}
+    {{- $labels := $github.labels }}
+    {{- if not $labels }}{{- $labels = list (required "A valid label(s) for PRs is required" (coalesce $github.label $globals.label)) }}{{- end }}
+    labels:
+    {{- range $l := $labels }}
+    - {{ $l }}
+    {{- end }}
+    {{- if and ($github.secretName) ($github.secretKey) }}
+    tokenRef:
+      secretName: {{ $github.secretName }}
+      key: {{ $github.secretKey }}
+    {{- end }}
+    {{- if $github.appSecretName }}
+    appSecretName: {{ $github.appSecretName }}
+    {{- end }}
+  requeueAfterSeconds: {{ $refresh | default 500 }}
+{{- end -}}
 
 {{/*
-Create chart name and version as used by the chart label.
+GitLab merge request generator body. Expected dict keys: gitlab, globals, repo, refresh.
 */}}
-{{- define "chart.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- define "chart.gitlabGenerator" -}}
+{{- $gitlab := .gitlab -}}
+{{- $globals := .globals -}}
+{{- $repo := .repo -}}
+{{- $refresh := .refresh -}}
+pullRequest:
+  gitlab:
+    api: {{ $gitlab.api }}
+    project: {{ coalesce $repo.project $gitlab.group |  required "A valid repo project / group ID is required" | squote}}
+    pullRequestState: {{ $gitlab.pullRequestState | default "opened" | squote }}
+    {{- $labels := $gitlab.labels }}
+    {{- if not $labels }}{{- $labels = list (required "A valid label(s) for PRs is required" (coalesce $gitlab.label $globals.label)) }}{{- end }}
+    labels:
+    {{- range $l := $labels }}
+    - {{ $l }}
+    {{- end }}
+    {{- if and ($gitlab.secretName) ($gitlab.secretKey) }}
+    tokenRef:
+      secretName: {{ $gitlab.secretName }}
+      key: {{ $gitlab.secretKey }}
+    {{- end }}
+    {{- if $gitlab.insecure }}
+    insecure: true
+    {{- end }}
+    {{- with $gitlab.caRef }}
+    caRef:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  requeueAfterSeconds: {{ $refresh | default 500 }}
+{{- end -}}
 
 {{/*
-Common labels
-*/}}
-{{- define "chart.labels" -}}
-helm.sh/chart: {{ include "chart.chart" . }}
-{{ include "chart.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
+Shared ArgoCD Application template body for the GitHub PR and GitLab MR
+ApplicationSets. The two generators are ~90% identical; the provider-specific
+values are pre-computed by each caller and passed via a dict so this template
+stays platform-agnostic and there is a single source of truth for the payload.
 
-{{/*
-Selector labels
+Expected dict keys:
+  repo                  the per-repo entry ($repo)
+  globals               .Values.globals (revisionHistoryLimit/annotations/syncOptions/deployToNamespace)
+  server                squoted ArgoCD server (include "chart.server")
+  retryBackoffDuration  sync retry backoff
+  project               pre-computed AppProject name or "default"
+  repoURL               pre-computed source repoURL
+  label                 pre-computed part-of label
+  path                  provider default source path
+  nameFormat            pre-computed Application metadata.name
+  externalLink          pre-computed external-link annotation value
+  infoKey               "pull_request" or "merge_request"
 */}}
-{{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "chart.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{- define "chart.globals" -}}
-{{ .Values.globals }}
-{{- end }}
+{{- define "chart.applicationTemplate" -}}
+{{- $dqf := "{{" -}}
+{{- $dqb := "}}" -}}
+{{- $branch := "{{ .branch }}" | squote -}}
+{{- $branchSlug := "{{ .branch_slug }}" | squote -}}
+{{- $headShortSha := "{{ .head_short_sha }}" | squote -}}
+{{- $repo := .repo -}}
+{{- $globals := .globals -}}
+{{- $server := .server -}}
+{{- $retryBackoffDuration := .retryBackoffDuration }}
+  template:
+    metadata:
+      name: {{ .nameFormat }}
+      labels:
+        app.kubernetes.io/name: {{ $repo.name }}
+        app.kubernetes.io/branch: {{ trunc 63 $branchSlug | trimSuffix "-" }}
+        app.kubernetes.io/created-by: 'applicationset'
+      annotations:
+        argocd.argoproj.io/head: {{ $headShortSha }}
+        link.argocd.argoproj.io/external-link: '{{ .externalLink }}'
+        {{- with $globals.annotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      revisionHistoryLimit: {{ $globals.revisionHistoryLimit }}
+      source:
+        repoURL: {{ .repoURL }}
+        {{- if and $repo $repo.parameters }}
+        helm:
+          parameters:
+            {{ toJson $repo.parameters | indent 0 }}
+        chart: {{ or $repo.chart $repo.name }}
+        targetRevision: {{ or $repo.targetRevision ">= 0" | quote }}
+        {{- else if and $repo $repo.values }}
+        helm:
+          values: |
+            {{ toJson $repo.values | indent 0 }}
+        {{- if and $repo $repo.chart }}
+        chart: {{ or $repo.chart $repo.name }}
+        {{- else if and $repo $repo.path }}
+        path: {{ $repo.path }}
+        {{- end }}
+        targetRevision: {{ or $repo.targetRevision $branch $headShortSha "HEAD" }}
+        {{- else }}
+        targetRevision: {{ or $repo.targetRevision $branch $headShortSha "HEAD" }}
+        kustomize:
+          namespace: {{ coalesce $repo.namespace $globals.deployToNamespace (printf "mr-%s .branch_slug %s-%s .number %s" $dqf $dqb $dqf $dqb) | quote }}
+          commonAnnotations:
+            app.kubernetes.io/instance: '{{ $repo.name }}'
+            app.kubernetes.io/part-of: {{ .label }}
+            argocd.argoproj.io/head_short_sha: '{{ $dqf }} .head_short_sha {{ $dqb }}'
+          {{- range $i, $r := $repo.images }}
+          {{- if eq $i 0 }}
+          images:
+          {{- end }}
+          - {{ $r | indent 0 | squote }}
+          {{- end }}
+        path: {{ coalesce $repo.path .path }}
+        {{- end }}
+      project: {{ .project }}
+      syncPolicy:
+        automated:
+          allowEmpty: true
+          prune: true
+          selfHeal: true
+        managedNamespaceMetadata:
+          labels:
+            app.kubernetes.io/created-by: {{ $repo.name }}
+        syncOptions:
+        {{- range $s := $globals.syncOptions }}
+          - {{ $s }}
+        {{- end }}
+        retry:
+          backoff:
+            duration: {{ $retryBackoffDuration }}
+      destination:
+        {{- if eq $server "all" }}
+        server: '{{ $dqf }} .server {{ $dqb }}'
+        {{- else }}
+        server: {{ $server | squote }}
+        {{- end }}
+        namespace: {{ coalesce $repo.namespace $globals.deployToNamespace (printf "mr-%s .branch_slug %s-%s .number %s" $dqf $dqb $dqf $dqb) | quote }}
+      info:
+        - name: author
+          value: '{{ $dqf }} .author {{ $dqb }}'
+        - name: branch
+          value: '{{ $dqf }} .branch {{ $dqb }}'
+        - name: target_branch
+          value: '{{ $dqf }} .target_branch_slug {{ $dqb }}'
+        - name: branch_slug
+          value: '{{ $dqf }} .branch_slug {{ $dqb }}'
+        - name: head_short_sha
+          value: '{{ $dqf }} .head_short_sha {{ $dqb }}'
+        - name: {{ .infoKey }}
+          value: '{{ $dqf }} .number {{ $dqb }}'
+{{- end -}}

--- a/charts/applicationset/templates/github-pr.yml
+++ b/charts/applicationset/templates/github-pr.yml
@@ -7,11 +7,7 @@
 {{- $namespace := include "chart.namespace" . -}}
 {{- $dqf := "{{" -}}
 {{- $dqb := "}}" -}}
-{{- $branch := "{{branch}}" | squote -}}
-{{- $branchSlug := "{{branch_slug}}" | squote -}}
-{{- $headShortSha := "{{head_short_sha}}" | squote -}}
 {{- $server := include "chart.server" . -}}
-{{- $notificationChannel := include "chart.notificationChannel" . -}}
 {{- $pr := contains "api.github.com" $github.api | ternary "https://github.com" $github.api -}}
 
 {{- range $key, $repo := .Values.repos.github }}
@@ -28,113 +24,28 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: '{{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}'
 spec:
+  goTemplate: true
+  {{- with $globals.goTemplateOptions }}
+  goTemplateOptions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   syncPolicy:
-    preserveResourcesOnDeletion: false
+    preserveResourcesOnDeletion: {{ $globals.preserveResourcesOnDeletion | default false }}
   generators:
   {{- if eq $server "all" }}
-  - clusters: {}
+  - matrix:
+      generators:
+      - clusters: {}
+      - {{ include "chart.githubGenerator" (dict "github" $github "globals" $globals "repo" $repo "refresh" $refresh) | nindent 8 | trim }}
+  {{- else }}
+  - {{ include "chart.githubGenerator" (dict "github" $github "globals" $globals "repo" $repo "refresh" $refresh) | nindent 4 | trim }}
   {{- end }}
-  - pullRequest:
-      github:
-        api: {{ $github.api }}
-        owner: {{ required "A valid repo organization / owner is required" $github.owner }}
-        repo: {{ required "A valid repo name is required" $repo.name }}
-        labels:
-        - {{ required "A valid label(s) for PRs is required" (coalesce $github.label $globals.label) }}
-        {{- if and ($github.secretName) ($github.secretKey) }}
-        tokenRef:
-          secretName: {{ $github.secretName }}
-          key: {{ $github.secretKey }}
-        {{- end }}
-        {{- if $github.appSecretName }}
-        appSecretName: {{ $github.appSecretName }}
-        {{- end }}
-      requeueAfterSeconds: {{ $refresh | default 500 }}
-  template:
-    metadata:
-      name: {{ printf "%s-%shead_short_sha_7%s-%snumber%s-%s" $repo.name $dqf $dqb $dqf $dqb $name }}
-      labels:
-        app.kubernetes.io/name: {{ $repo.name }}
-        app.kubernetes.io/branch: {{ trunc 63 $branchSlug | trimSuffix "-" }}
-        app.kubernetes.io/created-by: 'applicationset'
-      annotations:
-        argocd.argoproj.io/head: {{ $headShortSha }}
-        link.argocd.argoproj.io/external-link: '{{ $pr }}/{{ $github.owner }}/{{or $repo.name $repo.path}}/pull/{{ $dqf }}number{{ $dqb }}'
-        {{- with $globals.annotations }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-    spec:
-      revisionHistoryLimit: {{ $globals.revisionHistoryLimit }}
-      source:
-        {{- $localRepoUrl := printf "https://github.com/%s/%s.git" $github.owner $repo.name }}
-        repoURL: {{ coalesce $repo.repoUrl $localRepoUrl }}
-        {{- if and $repo $repo.parameters }}
-        helm:
-          parameters:
-            {{ toJson $repo.parameters | indent 0 }}
-        chart: {{ or $repo.chart $repo.name }}
-        targetRevision: {{ or $repo.targetRevision ">= 0" | quote }}
-        {{- else if and $repo $repo.values }}
-        helm:
-          values: |
-            {{ toJson $repo.values | indent 0 }}
-        {{- if and $repo $repo.chart }}
-        chart: {{ or $repo.chart $repo.name }}
-        {{- else if and $repo $repo.path }}
-        path: {{ $repo.path }}
-        {{- end }}
-        targetRevision: {{ or $repo.targetRevision $branch $headShortSha "HEAD" }}
-        {{- else }}
-        targetRevision: {{ or $repo.targetRevision $branch $headShortSha "HEAD" }}
-        kustomize:
-          namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) | quote }}
-          commonAnnotations:
-            app.kubernetes.io/instance: '{{ $repo.name }}'
-            app.kubernetes.io/part-of: {{ coalesce $github.label $globals.label }}
-            argocd.argoproj.io/head_short_sha: '{{ $dqf }}head_short_sha{{ $dqb }}'
-          {{- range $i, $r := $repo.images }}
-          {{- if eq $i 0 }}
-          images:
-          {{- end }}
-          - {{ $r | indent 0 | squote }}
-          {{- end }}
-        path: {{ coalesce $repo.path $github.path }}
-        {{- end }}
-      project: {{ and $.Values.project $.Values.project.enabled | ternary $name "default" }}
-      syncPolicy:
-        automated:
-          allowEmpty: true
-          prune: true
-          selfHeal: true
-        managedNamespaceMetadata:
-          labels:
-            app.kubernetes.io/created-by: {{ $repo.name }}
-        syncOptions:
-        {{- range $s := $globals.syncOptions }}
-          - {{ $s }}
-        {{- end }}
-        retry:
-          backoff:
-            duration: {{ $retryBackoffDuration }}
-      destination:
-        {{- if eq $server "all" }}
-        server: '{{ $dqf }}server{{ $dqb }}'
-        {{- else }}
-        server: {{ $server }}
-        {{- end }}
-        namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) | quote }}
-      info:
-        - name: author
-          value: '{{ $dqf }}author{{ $dqb }}'
-        - name: branch
-          value: '{{ $dqf }}branch{{ $dqb }}'
-        - name: target_branch
-          value: '{{ $dqf }}target_branch_slug{{ $dqb }}'
-        - name: branch_slug
-          value: '{{ $dqf }}branch_slug{{ $dqb }}'
-        - name: head_short_sha
-          value: '{{ $dqf }}head_short_sha{{ $dqb }}'
-        - name: pull_request
-          value: '{{ $dqf }}number{{ $dqb }}'
+  {{- $localRepoUrl := printf "https://github.com/%s/%s.git" $github.owner $repo.name -}}
+  {{- $repoURL := coalesce $repo.repoUrl $localRepoUrl -}}
+  {{- $externalLink := printf "%s/%s/%s/pull/%s .number %s" $pr $github.owner (or $repo.name $repo.path) $dqf $dqb -}}
+  {{- $nameFormat := printf "%s-%s .head_short_sha_7 %s-%s .number %s-%s" $repo.name $dqf $dqb $dqf $dqb $name -}}
+  {{- $label := coalesce $github.label $globals.label -}}
+  {{- $project := and $.Values.project $.Values.project.enabled | ternary $name "default" -}}
+{{- include "chart.applicationTemplate" (dict "repo" $repo "globals" $globals "server" $server "retryBackoffDuration" $retryBackoffDuration "project" $project "repoURL" $repoURL "label" $label "path" $github.path "nameFormat" $nameFormat "externalLink" $externalLink "infoKey" "pull_request") }}
 {{- end }}
 {{- end }}

--- a/charts/applicationset/templates/gitlab-mr.yml
+++ b/charts/applicationset/templates/gitlab-mr.yml
@@ -7,11 +7,7 @@
 {{- $namespace := include "chart.namespace" . -}}
 {{- $dqf := "{{" -}}
 {{- $dqb := "}}" -}}
-{{- $branch := "{{branch}}" | squote -}}
-{{- $branchSlug := "{{branch_slug}}" | squote -}}
-{{- $headShortSha := "{{head_short_sha}}" | squote -}}
 {{- $server := include "chart.server" . -}}
-{{- $notificationChannel := include "chart.notificationChannel" . -}}
 
 {{- range $key, $repo := .Values.repos.gitlab }}
 ---
@@ -27,107 +23,28 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: '{{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}'
 spec:
+  goTemplate: true
+  {{- with $globals.goTemplateOptions }}
+  goTemplateOptions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   syncPolicy:
-    preserveResourcesOnDeletion: false
+    preserveResourcesOnDeletion: {{ $globals.preserveResourcesOnDeletion | default false }}
   generators:
   {{- if eq $server "all" }}
-  - clusters: {}
+  - matrix:
+      generators:
+      - clusters: {}
+      - {{ include "chart.gitlabGenerator" (dict "gitlab" $gitlab "globals" $globals "repo" $repo "refresh" $refresh) | nindent 8 | trim }}
+  {{- else }}
+  - {{ include "chart.gitlabGenerator" (dict "gitlab" $gitlab "globals" $globals "repo" $repo "refresh" $refresh) | nindent 4 | trim }}
   {{- end }}
-  - pullRequest:
-      gitlab:
-        api: {{ $gitlab.api }}
-        project: {{ coalesce $repo.project $gitlab.group |  required "A valid repo project / group ID is required" | squote}}
-        pullRequestState: 'opened'
-        labels:
-        - {{ required "A valid label(s) for PRs is required" (coalesce $gitlab.label $globals.label) }}
-        {{- if and ($gitlab.secretName) ($gitlab.secretKey) }}
-        tokenRef:
-          secretName: {{ $gitlab.secretName }}
-          key: {{ $gitlab.secretKey }}
-        {{- end }}
-      requeueAfterSeconds: {{ $refresh | default 500 }}
-  template:
-    metadata:
-      name: {{ printf "%s-%sbranch_slug%s-%snumber%s-%s" $repo.name $dqf $dqb $dqf $dqb $name}}
-      labels:
-        app.kubernetes.io/name: {{ $repo.name }}
-        app.kubernetes.io/branch: {{ trunc 63 $branchSlug | trimSuffix "-" }}
-        app.kubernetes.io/created-by: 'applicationset'
-      annotations:
-        argocd.argoproj.io/head: {{ $headShortSha }}
-        link.argocd.argoproj.io/external-link: '{{ $gitlab.api }}/{{ $gitlab.group }}/{{or $repo.name $repo.path}}/-/merge_requests/{{ $dqf }}number{{ $dqb }}'
-        {{- with $globals.annotations }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-    spec:
-      revisionHistoryLimit: {{ $globals.revisionHistoryLimit }}
-      source:
-        {{- $localRepoUrl := printf "%s/%s/%s.git" $gitlab.api $gitlab.group $repo.name }}
-        repoURL: {{ coalesce $repo.repoUrl $localRepoUrl }}
-        {{- if and $repo $repo.parameters }}
-        helm:
-          parameters:
-            {{ toJson $repo.parameters | indent 0 }}
-        chart: {{ or $repo.chart $repo.name }}
-        targetRevision: {{ or $repo.targetRevision ">= 0" | quote }}
-        {{- else if and $repo $repo.values }}
-        helm:
-          values: |
-            {{ toJson $repo.values | indent 0 }}
-        {{- if and $repo $repo.chart }}
-        chart: {{ or $repo.chart $repo.name }}
-        {{- else if and $repo $repo.path }}
-        path: {{ $repo.path }}
-        {{- end }}
-        targetRevision: {{ or $repo.targetRevision $branch $headShortSha "HEAD" }}
-        {{- else }}
-        targetRevision: {{ or $repo.targetRevision $branch $headShortSha "HEAD" }}
-        kustomize:
-          namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) | quote }}
-          commonAnnotations:
-            app.kubernetes.io/instance: '{{ $repo.name }}'
-            app.kubernetes.io/part-of: {{ coalesce $gitlab.label $globals.label }}
-            argocd.argoproj.io/head_short_sha: '{{ $dqf }}head_short_sha{{ $dqb }}'
-          {{- range $i, $r := $repo.images }}
-          {{- if eq $i 0 }}
-          images:
-          {{- end }}
-          - {{ $r | indent 0 | squote }}
-          {{- end }}
-        path: {{ coalesce $repo.path $gitlab.path }}
-        {{- end }}
-      project: {{ and $.Values.project $.Values.project.enabled | ternary $name "default" }}
-      syncPolicy:
-        automated:
-          allowEmpty: true
-          prune: true
-          selfHeal: true
-        syncOptions:
-        {{- range $s := $globals.syncOptions }}
-          - {{ $s }}
-        {{- end }}
-        retry:
-          backoff:
-            duration: {{ $retryBackoffDuration }}
-      destination:
-        {{- if eq $server "all" }}
-        server: '{{ $dqf }}server{{ $dqb }}'
-        {{- else }}
-        server: {{ $server }}
-        {{- end }}
-        namespace: {{ coalesce $repo.namespace $.Values.globals.deployToNamespace (printf "mr-%sbranch_slug%s-%snumber%s" $dqf $dqb $dqf $dqb) | quote }}
-      info:
-        - name: author
-          value: '{{ $dqf }}author{{ $dqb }}'
-        - name: branch
-          value: '{{ $dqf }}branch{{ $dqb }}'
-        - name: target_branch
-          value: '{{ $dqf }}target_branch_slug{{ $dqb }}'
-        - name: branch_slug
-          value: '{{ $dqf }}branch_slug{{ $dqb }}'
-        - name: head_short_sha
-          value: '{{ $dqf }}head_short_sha{{ $dqb }}'
-        - name: merge_request
-          value: '{{ $dqf }}number{{ $dqb }}'
+  {{- $localRepoUrl := printf "%s/%s/%s.git" $gitlab.api $gitlab.group $repo.name -}}
+  {{- $repoURL := coalesce $repo.repoUrl $localRepoUrl -}}
+  {{- $externalLink := printf "%s/%s/%s/-/merge_requests/%s .number %s" $gitlab.api $gitlab.group (or $repo.name $repo.path) $dqf $dqb -}}
+  {{- $nameFormat := printf "%s-%s .branch_slug %s-%s .number %s-%s" $repo.name $dqf $dqb $dqf $dqb $name -}}
+  {{- $label := coalesce $gitlab.label $globals.label -}}
+  {{- $project := and $.Values.project $.Values.project.enabled | ternary $name "default" -}}
+{{- include "chart.applicationTemplate" (dict "repo" $repo "globals" $globals "server" $server "retryBackoffDuration" $retryBackoffDuration "project" $project "repoURL" $repoURL "label" $label "path" $gitlab.path "nameFormat" $nameFormat "externalLink" $externalLink "infoKey" "merge_request") }}
 {{- end }}
 {{- end }}

--- a/charts/applicationset/values.yaml
+++ b/charts/applicationset/values.yaml
@@ -24,7 +24,16 @@ globals:
   # -- (string) The amount to back off retries of failed syncs
   retryBackoffDuration: '10s'
 
-  # -- ArgoCD server address, use 'all' to use cluster generator
+  # -- (list) Go template options for the ApplicationSet controller. 'missingkey=error'
+  # fails rendering on any unresolved template key - see ArgoCD ApplicationSet docs.
+  goTemplateOptions:
+    - missingkey=error
+
+  # -- Preserve an Application's child resources when the parent Application is deleted
+  preserveResourcesOnDeletion: false
+
+  # -- ArgoCD server address. Use 'all' to deploy each preview to every registered
+  # cluster (renders a matrix of the cluster generator and the pull request generator)
   server: 'https://kubernetes.default.svc'
 
   # -- Kubernetes namespace to deploy previews
@@ -78,6 +87,10 @@ project:
 github:
   api: https://api.github.com
   label: 'preview'
+  # -- (list) Filter PRs by multiple labels (a PR must carry ALL of them). Overrides `label` when set.
+  # labels:
+  #   - preview
+  #   - ready
   owner: 'saidsef'
   path: 'deployment'
   secretName: ''
@@ -89,12 +102,23 @@ gitlab:
   api: https://gitlab.com
   group: 'saidsef'
   label: 'preview'
+  # -- (list) Filter MRs by multiple labels (an MR must carry ALL of them). Overrides `label` when set.
+  # labels:
+  #   - preview
+  # -- MR state filter, one of: "", opened, closed, merged or locked
+  pullRequestState: 'opened'
+  # -- Skip validating the GitLab TLS certificate (useful for self-signed certificates)
+  insecure: false
+  # -- ConfigMap holding trusted CA certs for self-signed GitLab TLS (leave empty to disable)
+  caRef: {}
+  #  configMapName: argocd-tls-certs-cm
+  #  key: gitlab-ca
   path: 'deployment'
   secretName: ''
   secretKey: ''
 
 # -- List of repo names and override images for preview environment
-# to dynamically pass the branch of the pull request head use '{{branch_slug}}' variable
+# to dynamically pass the branch of the pull request head use '{{ .branch_slug }}' variable
 # see: https://argocd-applicationset.readthedocs.io/en/stable/Generators-Pull-Request/#template
 repos:
   gitlab: {}
@@ -106,15 +130,15 @@ repos:
   github:
   - name: node-webserver
     images:
-    - 'docker.io/saidsef/node-webserver:{{branch_slug}}'
+    - 'docker.io/saidsef/node-webserver:{{ .branch_slug }}'
   - name: alpine-jenkins-dockerfile
     path: 'deployment/preview'
   - name: aws-kinesis-local
     images:
-    - 'docker.io/saidsef/aws-kinesis-local:{{branch_slug}}'
+    - 'docker.io/saidsef/aws-kinesis-local:{{ .branch_slug }}'
   - name: aws-dynamodb-local
     images:
-    - 'docker.io/saidsef/aws-dynamodb-local:{{branch_slug}}'
+    - 'docker.io/saidsef/aws-dynamodb-local:{{ .branch_slug }}'
   - name: tika-document-to-text
     path: 'deployment/preview'
   - name: k8s-spot-termination-notice
@@ -124,14 +148,14 @@ repos:
     path: 'charts/scapy'
     values:
       image:
-        tag: '{{branch_slug}}'
+        tag: '{{ .branch_slug }}'
   - name: faas-reverse-geocoding
     chart: 'reverse-geocoding'
     repoUrl: 'https://saidsef.github.io/faas-reverse-geocoding'
     parameters:
       - name: "image.tag"
-        value: "{{branch_slug}}"
+        value: "{{ .branch_slug }}"
       - name: "ingress.enabled"
         value: "true"
       - name: "ingress.hosts[0].host"
-        value: "{{branch_slug}}"
+        value: "{{ .branch_slug }}"


### PR DESCRIPTION
## What

Modernises the `applicationset` chart and fixes the `server: all` option.

- **Go Template.** Migrates the GitHub PR / GitLab MR generators from the deprecating fasttemplate syntax (`{{number}}`) to Go Template (`goTemplate: true`, `{{ .number }}`), in line with current ArgoCD guidance.
- **New options.** `goTemplateOptions`, `preserveResourcesOnDeletion`, GitLab `pullRequestState` / `insecure` / `caRef`, and multi-label PR/MR filtering.
- **Fix `server: all`.** It was broken: `chart.server` was single-quoted, so the `eq "all"` check never matched and the destination rendered as `server: 'all'`. It now renders a matrix of the cluster and pull request generators. Each generated Application is suffixed with the cluster name (`nameNormalized`) so the names stay unique per cluster - otherwise every cluster produced the same Application name and ArgoCD kept only one, so previews never reached the other clusters.
- **Cleanup.** Deduplicates the two provider templates into shared named templates and removes unused chart helpers. GitLab MRs now set `managedNamespaceMetadata` for parity with GitHub.
- **CI.** The kind test applies the rendered chart server-side.

## Breaking change

With `goTemplate: true` the controller evaluates tokens inside your `repos[].images`, `.values` and `.parameters`. Update them from `{{branch_slug}}` to `{{ .branch_slug }}` (and `.number`, `.head_short_sha`, and similar).

## Testing

- `helm lint` and `helm template` across the default, project, gitlab, secrets, multi-label and all-cluster scenarios; the non all-cluster output is unchanged.
- Confirmed `server: all` names stay unique per cluster: `helm template --set globals.server=all` renders `...-{{ .nameNormalized }}` in each Application name, while the default server output keeps the original name.
- Deployed to a kind cluster running the ArgoCD ApplicationSet controller: templates render under `missingkey=error`, the new fields round-trip through the API, and an all-cluster matrix generates an Application targeting the cluster's server.